### PR TITLE
Add support for import declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,30 @@
 
 Babel plugin for inlining values from `package.json`
 
+Using `require`:
+
 Input:
-```js
+
+```javascript
 var version = require('./package.json').version;
 ```
+
 Output:
-```js
+
+```javascript
 var version = '1.0.0';
+```
+
+Using `import`:
+
+```javascript
+import { version } from '../package.json';
+```
+
+Output:
+
+```javascript
+const version = '1.0.0';
 ```
 
 The plugin can be used to import any value from a `package.json` file: primitives, objects, or arrays will all be injected into your compiled source as literal expressions.
@@ -37,7 +54,7 @@ $ babel --plugins inline-package-json script.js
 
 ### Via Node API
 
-```js
+```javascript
 require('babel-core').transform('code', {
   plugins: ['inline-package-json']
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,54 @@
 import path from 'path';
 
-export default function({types: t}) {
+export default function({ types: t }) {
+  function getValue(src, name, key) {
+    const basePath = path.resolve(src);
+    const pkg = require(path.join(basePath, '..', name));
+
+    return pkg[key];
+  }
+
+  function isPackageJSON(node) {
+    return t.isLiteral(node) && /package\.json$/.test(node.value);
+  }
+
   return {
     visitor: {
+      ImportDeclaration: function importDeclaration(treePath) {
+        const node = treePath.node;
+        const src = this.file.opts.filename;
+
+        if (!isPackageJSON(node.source)) {
+          return;
+        }
+
+        const variables = node.specifiers.filter(t.isImportSpecifier).map(specifier => {
+          const value = getValue(src, node.source.value, specifier.local.name);
+
+          return t.variableDeclaration('const', [t.variableDeclarator(specifier.local, t.valueToNode(value))]);
+        });
+
+        if (!variables.length) {
+          return;
+        }
+
+        return treePath.replaceWithMultiple(variables);
+      },
+
       MemberExpression: function MemberExpression(treePath) {
         const node = treePath.node;
-        if (t.isCallExpression(node.object) &&
-            t.isIdentifier(node.object.callee, { name: 'require' }) &&
-            t.isLiteral(node.object.arguments[0]) &&
-            node.object.arguments[0].value.match(/package\.json$/)) {
-          let srcPath = path.resolve(this.file.opts.filename);
-          let pkg = require(path.join(srcPath, '..', node.object.arguments[0].value));
-          let value = pkg[node.property.name];
-          treePath.replaceWith(t.expressionStatement(t.valueToNode(value)));
+        const src = this.file.opts.filename;
+
+        if (!t.isCallExpression(node.object) ||
+            !t.isIdentifier(node.object.callee, { name: 'require' }) ||
+            !isPackageJSON(node.object.arguments[0])) {
+          return;
         }
+
+        const value = getValue(src, node.object.arguments[0].value, node.property.name);
+
+        return treePath.replaceWith(t.expressionStatement(t.valueToNode(value)));
       }
     }
   }
-}
+};


### PR DESCRIPTION
Hey,

Thanks for this cool package. I really dislike having to copy the `package.json` to the distribution build of babel and this package allows me to do exactly just that.

I've noticed that support for the ES2015 modules was missing, so I've decided to submit this PR with support for that. Default exports won't get replaced, as expected, but no error will occur also.

I think it's time for the package to get some tests, I just didn't have the time to do it on this PR.
